### PR TITLE
removed double ack on receipt of EOT

### DIFF
--- a/docker/receiver.py
+++ b/docker/receiver.py
@@ -53,9 +53,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as udp_socket:
             
             # check if all data received (empty message)
             if len(message) == 0 and ack_id == seq_id:
-                ack = create_acknowledgement(ack_id, 'ack')
                 fin = create_acknowledgement(ack_id + 3, 'fin')
-                udp_socket.sendto(ack, client)
                 udp_socket.sendto(fin, client)
         except socket.timeout:
             timeouts += 1


### PR DESCRIPTION
when the receiver gets an empty message (signalling end of Tx), it should:
1. send acknowledgement of receipt of the empty message
2. send `fin`

the current code sends two `ack`s for the empty message